### PR TITLE
fix: Keep character creation window open after selection

### DIFF
--- a/public/games/rpg/game.js
+++ b/public/games/rpg/game.js
@@ -766,7 +766,7 @@ function handleConfirmCustomChar() {
 
     if (window.opener) {
         window.opener.postMessage({ type: 'character-selected', data: charData }, '*');
-        window.close();
+        // window.close(); // Removed as per user request
     } else {
         localStorage.setItem('selectedCharacter', JSON.stringify(charData));
         if (customCard) {
@@ -815,7 +815,7 @@ function handleConfirmPredefName() {
 
     if (window.opener) {
         window.opener.postMessage({ type: 'character-selected', data: charData }, '*');
-        window.close(); // Close the popup after sending the data
+        // window.close(); // Removed as per user request
     } else {
         // Fallback for when the page is not opened as a popup
         localStorage.setItem('selectedCharacter', JSON.stringify(charData));


### PR DESCRIPTION
This commit removes the `window.close()` calls from the character creation logic in `game.js`.

Previously, the pop-up window for character creation would close immediately after the character data was sent to the main window. As per user request, the window will now remain open, allowing the user to see their selection or make further changes before manually closing the window.